### PR TITLE
Added @types/p5 - fixes issues with TS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1262,6 +1262,11 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
+    "@types/p5": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@types/p5/-/p5-0.9.1.tgz",
+      "integrity": "sha512-4glOKdqdBiRWDFZwi/MjHudPV2U4t2L4fTTSacGapfFxyNXzZcAshAjqmrJkCIZcFlhRBEAL7AM95xRDMfrIwg=="
+    },
     "@types/semver": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "not op_mini all"
   ],
   "dependencies": {
+    "@types/p5": "^0.9.1",
     "p5": "^0.10.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Previously if I provided `setup` function with type `(p5: P5, canvas: Elem) => void` with `P5` from `@types/p5` it didn't compile as `P5` from `@types/p5`.

This should be fixed now.