### PR TITLE
fix window type check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,61 +1,61 @@
 import React from "react";
 import p5 from "p5";
 
-if (typeof window !== undefined) window.p5 = p5;
+if (typeof window !== "undefined") window.p5 = p5;
 export default class Sketch extends React.Component {
-	constructor(props) {
-		super(props);
-		this.canvasParentRef = React.createRef();
-	}
+  constructor(props) {
+    super(props);
+    this.canvasParentRef = React.createRef();
+  }
 
-	componentDidMount() {
-		this.sketch = new p5((p) => {
-			p.setup = () => {
-				this.props.setup(p, this.canvasParentRef.current);
-			};
-			const p5Events = [
-				"draw",
-				"windowResized",
-				"preload",
-				"mouseClicked",
-				"doubleClicked",
-				"mouseMoved",
-				"mousePressed",
-				"mouseWheel",
-				"mouseDragged",
-				"mouseReleased",
-				"keyPressed",
-				"keyReleased",
-				"keyTyped",
-				"touchStarted",
-				"touchMoved",
-				"touchEnded",
-				"deviceMoved",
-				"deviceTurned",
-				"deviceShaken",
-			];
-			p5Events.forEach((event) => {
-				if (this.props[event]) {
-					p[event] = () => {
-						this.props[event](p);
-					};
-				}
-			});
-		});
-	}
-	shouldComponentUpdate() {
-		return false;
-	}
-	componentWillUnmount() {
-		this.sketch.remove();
-	}
-	render() {
-		return (
-			<div
-				ref={this.canvasParentRef}
-				className={this.props.className || "react-p5"}
-				style={this.props.style || {}}
-			/>
-		);
-	}
+  componentDidMount() {
+    this.sketch = new p5((p) => {
+      p.setup = () => {
+        this.props.setup(p, this.canvasParentRef.current);
+      };
+      const p5Events = [
+        "draw",
+        "windowResized",
+        "preload",
+        "mouseClicked",
+        "doubleClicked",
+        "mouseMoved",
+        "mousePressed",
+        "mouseWheel",
+        "mouseDragged",
+        "mouseReleased",
+        "keyPressed",
+        "keyReleased",
+        "keyTyped",
+        "touchStarted",
+        "touchMoved",
+        "touchEnded",
+        "deviceMoved",
+        "deviceTurned",
+        "deviceShaken",
+      ];
+      p5Events.forEach((event) => {
+        if (this.props[event]) {
+          p[event] = () => {
+            this.props[event](p);
+          };
+        }
+      });
+    });
+  }
+  shouldComponentUpdate() {
+    return false;
+  }
+  componentWillUnmount() {
+    this.sketch.remove();
+  }
+  render() {
+    return (
+      <div
+        ref={this.canvasParentRef}
+        className={this.props.className || "react-p5"}
+        style={this.props.style || {}}
+      />
+    );
+  }
 }


### PR DESCRIPTION
The `typeof` operator returns a string, so `typeof window !== undefined` always evaluated to `true`, and as a result the value of `window.p5` was overwritten no matter what. The type check has been updated to use a string: `typeof window !== "undefined"`.