### PR TITLE
Adding brackets to the if one-liner statement checking if window defined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import p5 from "p5";
 
-if (typeof window !== "undefined") window.p5 = p5;
+if (typeof window !== "undefined") { window.p5 = p5 };
 export default class Sketch extends React.Component {
   constructor(props) {
     super(props);


### PR DESCRIPTION
Trying to prevent possible webpack errors on build for build SSR.
Possibly fixing #47.

If this change could be tested instead of merged, that would be preferable. Unfortunately I can't test it, as I am not sure how to go about development of `react-p5`. See: #48